### PR TITLE
Remove named-level-store in favor of level

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function MultiDrive (location, opts, cb) {
           ? xtend(self.opts, opts, { secretKey: secretKey })
           : xtend(self.opts, opts)
         var archive = drive.createArchive(key, _opts)
-        self.archives[name] = archive
+        self.archives[key.toString('hex')] = archive
         done()
       })
     }

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function MultiDrive (location, opts, cb) {
           ? xtend(self.opts, opts, { secretKey: secretKey })
           : xtend(self.opts, opts)
         var archive = drive.createArchive(key, _opts)
-        self.archives[key.toString('hex')] = archive
+        self.archives[directory] = archive
         done()
       })
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var namedLevel = require('named-level-store')
 var hyperdrive = require('hyperdrive')
 var explain = require('explain-error')
 var concat = require('concat-stream')
@@ -15,21 +14,21 @@ module.exports = MultiDrive
 
 // manage a collection of hyperdrives
 // (str, obj?, fn) -> null
-function MultiDrive (name, opts, cb) {
-  if (!(this instanceof MultiDrive)) return new MultiDrive(name, opts, cb)
+function MultiDrive (location, opts, cb) {
+  if (!(this instanceof MultiDrive)) return new MultiDrive(location, opts, cb)
 
   if (!cb) {
     cb = opts
     opts = {}
   }
 
-  assert.equal(typeof name, 'string', 'multidrive: name should be a string')
+  assert.equal(typeof location, 'string', 'multidrive: location should be a string')
   assert.equal(typeof opts, 'object', 'multidrive: opts should be an object')
   assert.equal(typeof cb, 'function', 'multidrive: cb should be a function')
 
   var self = this
 
-  this.db = namedLevel(name)
+  this.db = level(location)
   this.opts = opts
   this.archives = {}
   this.queue = []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "hyperdrive": "^7.8.0",
     "level": "^1.5.0",
     "map-limit": "0.0.1",
-    "named-level-store": "^1.0.0",
     "pump": "^1.0.1",
     "run-series": "^1.1.4",
     "xtend": "^4.0.1"

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ var multidrive = require('./')
 test('drive = multidrive', function (t) {
   t.test('should assert input types', function (t) {
     t.plan(3)
-    t.throws(multidrive, /name/)
+    t.throws(multidrive, /location/)
     t.throws(multidrive.bind(null, 'hi'), /function/)
     t.throws(multidrive.bind(null, 'hi', 'hi', 'hi'), /object/)
   })
@@ -18,29 +18,30 @@ test('drive = multidrive', function (t) {
 test('drive.createArchive', function (t) {
   t.test('should assert input types', function (t) {
     t.plan(3)
-    var name = uuid()
-    multidrive(name, function (err, drive) {
+    var location = path.join('/tmp', uuid())
+
+    multidrive(location, function (err, drive) {
       t.ifError(err, 'no err')
       t.throws(drive.createArchive, /directory/)
       t.throws(drive.createArchive.bind(drive, '/foo/bar', 'nope'), /function/)
-      rimraf.sync(path.join(process.env.HOME, '.level', name))
+      rimraf.sync(location)
     })
   })
 
   t.test('should create an archive', function (t) {
     t.plan(2)
-    var name = uuid()
+    var location = path.join('/tmp', uuid())
 
     var opts = {
       file: function (name, dir) { return raf(path.join(dir, name)) }
     }
-    multidrive(name, opts, function (err, drive) {
+    multidrive(location, opts, function (err, drive) {
       t.ifError(err, 'no err')
 
       var archiveDir = path.join('/tmp', uuid())
       drive.createArchive(archiveDir, function (err, drive) {
         t.ifError(err, 'no err')
-        rimraf.sync(path.join(process.env.HOME, '.level', name))
+        rimraf.sync(location)
         rimraf.sync(archiveDir)
       })
     })


### PR DESCRIPTION
While handy in independent development, for dat-desktop we need to be able to specify exactly where the management db is being created, so you can remove all state by `rm -Rf ~/Downloads/dat`. Hence this PR against the `archivist` branch removes the `named-level-store` module in favor of simply passing a `location` argument.