### PR TITLE
switch to pure async factory pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ multidrive('my-cool-drive', function (err, drive) {
 
   drive.createArchive(process.cwd(), function (err, archive) {
     if (err) return console.error(err)
-
     // archive === [HyperDriveArchive]
-    drive.list(function (err, archives) {
-      if (err) console.error(err)
 
-      // archives === { '/usr/tiny-cat/drives': [HyperDriveArchive] }
-      Object.keys(archives).forEach(function (key) {
-        var archive = archives[key]
-        discovery(archive)
-      })
+    var archives = drive.list()
+    // archives === { '/usr/tiny-cat/drives': [HyperDriveArchive] }
+
+    Object.keys(archives).forEach(function (key) {
+      var archive = archives[key]
+      discovery(archive)
     })
   })
 })
@@ -68,9 +66,9 @@ call internally. `opts` can have the following values:
 }
 ```
 
-### drive.list(callback(err, drives))
-List all `archives` in the `multidrive`. `drives` is a key-value object where
-keys are file paths, and values are hyperdrive archives.
+### drive.list()
+List all `archives` in the `multidrive`. The returned `drives` key-value object
+lists keys as file paths and values as hyperdrive archives.
 
 ### drive.createArchive(location, [opts], callback(err, drive))
 Create a new named `hyperdrive` under `location`. To replicate an existing

--- a/index.js
+++ b/index.js
@@ -113,9 +113,7 @@ MultiDrive.prototype.createArchive = function (directory, opts, cb) {
 
     opts = xtend(self.opts, opts)
     var drive = hyperdrive(db)
-    var archive = (key)
-      ? drive.createArchive(key, opts)
-      : drive.createArchive(opts)
+    var archive = drive.createArchive(key, opts)
     archive.metadata.location = directory
 
     var secretKeyPath = path.join(directory, 'SECRET_KEY')

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var hyperdrive = require('hyperdrive')
 var explain = require('explain-error')
 var concat = require('concat-stream')
+var keyBy = require('lodash.keyby')
 var mapLimit = require('map-limit')
 var series = require('run-series')
 var assert = require('assert')
@@ -10,13 +11,11 @@ var path = require('path')
 var pump = require('pump')
 var fs = require('fs')
 
-module.exports = MultiDrive
+module.exports = createMultiDrive
 
 // manage a collection of hyperdrives
 // (str, obj?, fn) -> null
-function MultiDrive (location, opts, cb) {
-  if (!(this instanceof MultiDrive)) return new MultiDrive(location, opts, cb)
-
+function createMultiDrive (location, opts, cb) {
   if (!cb) {
     cb = opts
     opts = {}
@@ -26,28 +25,23 @@ function MultiDrive (location, opts, cb) {
   assert.equal(typeof opts, 'object', 'multidrive: opts should be an object')
   assert.equal(typeof cb, 'function', 'multidrive: cb should be a function')
 
-  var self = this
+  var db = level(location)
 
-  this.db = level(location)
-  this.opts = opts
-  this.archives = {}
-  this.queue = []
-
-  var rs = this.db.createReadStream()
+  var rs = db.createReadStream()
   pump(rs, concat({ encoding: 'json' }, sink), (err) => {
-    if (err) return cb(err)
-    cb(null, self)
+    if (err) cb(err)
   })
 
   function sink (pairs) {
-    mapLimit(pairs, 1, iterator, function (err) {
+    mapLimit(pairs, 1, iterator, function (err, archivesArray) {
       if (err) return cb(err)
-      while (self.queue.length) self.queue.shift()()
+      var archivesMap = keyBy(archivesArray, archive => archive.metadata.directory)
+      cb(null, new MultiDrive(db, archivesMap))
     })
 
     function iterator (pair, done) {
       var directory = pair.key
-      var opts = pair.value
+      var _opts = pair.value
 
       var secretKeyPath = path.join(directory, 'SECRET_KEY')
       var keyPath = path.join(directory, 'KEY')
@@ -88,11 +82,16 @@ function MultiDrive (location, opts, cb) {
           ? xtend(self.opts, opts, { secretKey: secretKey })
           : xtend(self.opts, opts)
         var archive = drive.createArchive(key, _opts)
-        self.archives[directory] = archive
-        done()
+        archive.metadata.location = directory
+        done(null, archive)
       })
     }
   }
+}
+
+function MultiDrive (db, archives) {
+  this.db = db
+  this.archives = archives
 }
 
 // (str, obj?, fn) -> null
@@ -165,9 +164,7 @@ MultiDrive.prototype.removeArchive = function (directory, cb) {
   this.db.del(directory, cb)
 }
 
-// (fn) -> null
-MultiDrive.prototype.list = function (cb) {
-  assert.equal(typeof cb, 'function', 'multidrive.list: cb should be a function')
-  if (this.ready) cb(null, this.archives)
-  else this.queue.push(cb)
+// () -> object
+MultiDrive.prototype.list = function () {
+  return this.archives
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function createMultiDrive (location, opts, cb) {
 
     function iterator (pair, done) {
       var directory = pair.key
-      var _opts = pair.value
+      opts = xtend(opts, pair.value)
 
       var secretKeyPath = path.join(directory, 'SECRET_KEY')
       var keyPath = path.join(directory, 'KEY')
@@ -80,10 +80,8 @@ function createMultiDrive (location, opts, cb) {
       series(fns, function (err) {
         if (err) return done(err)
         var drive = hyperdrive(db)
-        var _opts = (secretKey)
-          ? xtend(self.opts, opts, { secretKey: secretKey })
-          : xtend(self.opts, opts)
-        var archive = drive.createArchive(key, _opts)
+        if (secretKey) opts.secretKey = secretKey
+        var archive = drive.createArchive(key, opts)
         archive.metadata.location = directory
         done(null, archive)
       })
@@ -113,11 +111,11 @@ MultiDrive.prototype.createArchive = function (directory, opts, cb) {
   level(directory, function (err, db) {
     if (err) return cb(explain(err, 'multidrive.createArchive: error creating database'))
 
-    var _opts = xtend(self.opts, opts)
+    opts = xtend(self.opts, opts)
     var drive = hyperdrive(db)
     var archive = (key)
-      ? drive.createArchive(key, _opts)
-      : drive.createArchive(_opts)
+      ? drive.createArchive(key, opts)
+      : drive.createArchive(opts)
     archive.metadata.location = directory
 
     var secretKeyPath = path.join(directory, 'SECRET_KEY')

--- a/index.js
+++ b/index.js
@@ -28,14 +28,16 @@ function createMultiDrive (location, opts, cb) {
   var db = level(location)
 
   var rs = db.createReadStream()
-  pump(rs, concat({ encoding: 'json' }, sink), (err) => {
+  pump(rs, concat({ encoding: 'json' }, sink), function (err) {
     if (err) cb(err)
   })
 
   function sink (pairs) {
     mapLimit(pairs, 1, iterator, function (err, archivesArray) {
       if (err) return cb(err)
-      var archivesMap = keyBy(archivesArray, archive => archive.metadata.directory)
+      var archivesMap = keyBy(archivesArray, function (archive) {
+        return archive.metadata.directory
+      })
       cb(null, new MultiDrive(db, archivesMap))
     })
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "explain-error": "^1.0.3",
     "hyperdrive": "^7.8.0",
     "level": "^1.5.0",
+    "lodash.keyby": "^4.6.0",
     "map-limit": "0.0.1",
     "pump": "^1.0.1",
     "run-series": "^1.1.4",


### PR DESCRIPTION
Instead of also offering the internal queue, switch to a pure async factory pattern and simplify flow control in general.